### PR TITLE
fix(marketplace): add required `owner` field to marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,9 @@
 {
   "name": "video-analyzer",
+  "owner": {
+    "name": "docusphere",
+    "url": "https://github.com/docusphere"
+  },
   "metadata": {
     "display_name": "Video Analyzer",
     "description": "Analyze any video and produce an Agentic Video Transcript (.avt) — structured text with timestamped transcripts, visual descriptions, scene tags, and frame references.",


### PR DESCRIPTION
## Summary

Fixes the `/plugin marketplace add docusphere/video-analyzer` install path documented in the README's "Option C: Plugin Marketplace" section.

Claude Code's marketplace schema requires a top-level `owner` object alongside `name`, `metadata`, and `plugins[]`. Without it, install fails with:

```
Error: Failed to parse marketplace file at
.../marketplace.json:
Invalid schema:
.../marketplace.json
owner: Invalid input: expected object, received undefined
```

This adds the minimal `owner` block — `{ name, url }` pointing at the `docusphere` GitHub org. Adjust the values if you'd prefer a different display name or URL (e.g. a website rather than the GitHub org).

Fixes #1

## Test plan

- [x] `python3 -c "import json; json.load(open('.claude-plugin/marketplace.json'))"` — JSON parses
- [ ] After merge: `/plugin marketplace add docusphere/video-analyzer` succeeds in Claude Code
- [ ] `/plugin install analyze@video-analyzer` then exercises the plugin

---

[Written by Claude]